### PR TITLE
Cleanup error handling

### DIFF
--- a/sm_err.c
+++ b/sm_err.c
@@ -18,22 +18,28 @@ static void sm_err_print_err(const char *errstr)
     return;
 }
 
-void sm_err_window(const char *fmt, ...)
+static void sm_err_setv(const char *fmt, va_list *ap)
 {
     int rc;
-    va_list ap = {0};
-
-    va_start(ap, fmt);
 
     free(errbuf);
     errbuf = NULL;
 
-    rc = vasprintf(&errbuf, fmt, ap);
+    rc = vasprintf(&errbuf, fmt, *ap);
     if (rc < 0) {
-        va_end(ap);
         sm_err_print_err("Cannot allocate memory attempting to set an error!");
         exit(EXIT_FAILURE);
     }
+
+    return;
+}
+
+void sm_err_window(const char *fmt, ...)
+{
+    va_list ap = {0};
+
+    va_start(ap, fmt);
+    sm_err_setv(fmt, &ap);
     va_end(ap);
 
     display_status_window(errbuf, "Error");
@@ -43,25 +49,14 @@ void sm_err_window(const char *fmt, ...)
 
 void sm_err_set(const char *fmt, ...)
 {
-    int rc;
     va_list ap = {0};
 
     va_start(ap, fmt);
-
-    free(errbuf);
-    errbuf = NULL;
-
-    rc = vasprintf(&errbuf, fmt, ap);
-    if (rc < 0) {
-        va_end(ap);
-        sm_err_print_err("Cannot allocate memory attempting to set an error!");
-        exit(EXIT_FAILURE);
-    }
+    sm_err_setv(fmt, &ap);
+    va_end(ap);
 
     sm_err_print_err(errbuf);
-    va_end(ap);
     exit(1);
-    return;
 }
 
 const char * sm_err_get(void)


### PR DESCRIPTION
Make sm_error a bit cleaner - initially this wasn't meant to exit and I messed that up.
Effecitvely if you call `sm_err_set` it ends the cursor session and prints to stderr then exits. Its a _very_ basic "error and give up" handler. Originally it just set an error into an error buffer you could get with `sm_err_get`. It was meant to do that, it should probably do that at some point in the future but that is not needed for now.

Cleaned up invocation id error handling. Some minor changes
- declare variables at start of function (purely stylistic, happy for you to say no on this)
- Remove some unnecessary bracing around some if statements. Again stylistic.
- You probably wanted an error to be displayed to the user, the "sm_err_window" will do this in the manner you're looking for by flushing what you wanted to put into a status window. Whats nice about it is it takes `printf` like formatting so error reporting is easier.
- Dont `return rc` on error, but `goto fin`. This is because there is a cleanup routine at the end of the function that frees memory. If you just return you'll end up with a memory leak.

As an addage, the rewrite *was* huge and I've basically made a lot of internal API changes in regards to the naming scheme being used. So no worries I made this a lot more complicated!
Additionally I've done a terrible job of documenting this code...

Note: At this point I've just tried to turn it into a 'mini project, project' as a means to just understand the way I'm building C programs (modules in separate files, etc). I realize that its not really that necessary for a relatively small project like this.

However, lots of people (IMO) write poor C. The top-notch projects do it better than me also (systemd is a good one to look at).