### PR TITLE
Handle smaller terminals a little more gracefully

### DIFF
--- a/display.h
+++ b/display.h
@@ -12,7 +12,9 @@
 #define D_VERSION        "1.4.2"
 #define D_FUNCTIONS      "F1:START F2:STOP F3:RESTART F4:ENABLE F5:DISABLE F6:MASK F7:UNMASK F8:RELOAD"
 #define D_SERVICE_TYPES  "A:ALL D:DEV I:SLICE S:SERVICE O:SOCKET T:TARGET R:TIMER M:MOUNT C:SCOPE N:AMOUNT W:SWAP P:PATH H:SSHOT"
-#define D_HEADLINE       "ServiceMaster "D_VERSION"|Q/ESC:Quit"
+#define D_HEADLINE       "ServiceMaster "D_VERSION""
+#define D_NAVIGATION     "Left/Right: Modus | Up/Down: Select | Return: Show status"
+#define D_QUIT           "Q/ESC:Quit"
 
 #define D_XLOAD 104
 #define D_XACTIVE 114


### PR DESCRIPTION
Adding a row to split the navigation from the description part. Moving the types and controls onto their own lines. It should scale down to add another line and split those further, but that's about it. At some point it becomes unreadable anyways so no point it trying to handle smaller than that.

The colors are still a bit distracting, but I guess that's just their nature.

![image](https://github.com/user-attachments/assets/ab56b01c-1578-4dba-96db-bc505f6b68bd)
